### PR TITLE
Spec compliance and better exceptions

### DIFF
--- a/src/ObjectBuilder.cs
+++ b/src/ObjectBuilder.cs
@@ -131,6 +131,11 @@ namespace AutoRest.Modeler
             }
             if (SwaggerObject.Type == DataType.Array)
             {
+                if (SwaggerObject.Items == null)
+                {
+                    throw new Exception($"Invalid Swagger: Missing 'items' definition of an 'array' type.");
+                }
+
                 string itemServiceTypeName;
                 if (SwaggerObject.Items.Reference != null)
                 {

--- a/src/ParameterBuilder.cs
+++ b/src/ParameterBuilder.cs
@@ -70,11 +70,16 @@ namespace AutoRest.Modeler
             var swaggerParameter = Modeler.Unwrap(_swaggerParameter);
 
             // create service type
-            var serviceType = swaggerParameter.In == ParameterLocation.Body ?
-                swaggerParameter.Schema.GetBuilder(Modeler).BuildServiceType(serviceTypeName) :
-                swaggerParameter.GetBuilder(Modeler).ParentBuildServiceType(serviceTypeName);
-            
-            return serviceType;
+            if (swaggerParameter.In == ParameterLocation.Body)
+            {
+                if (swaggerParameter.Schema == null)
+                {
+                    throw new Exception($"Invalid Swagger: Body parameter{(serviceTypeName == null ? "" : $" '{serviceTypeName}'")} missing 'schema'.");
+                }
+                return swaggerParameter.Schema.GetBuilder(Modeler).BuildServiceType(serviceTypeName);
+            }
+
+            return swaggerParameter.GetBuilder(Modeler).ParentBuildServiceType(serviceTypeName);
         }
 
         public override IModelType ParentBuildServiceType(string serviceTypeName) => base.BuildServiceType(serviceTypeName);


### PR DESCRIPTION
- addresses https://github.com/Azure/autorest/issues/2540
- makes AutoRest do the right thing for a data plane spec that specifies `Accept` header - which is fine as per Swagger spec, but "shall be ignored" by tools