### PR TITLE
Adding model properties or parameters with "enum" constraint to the codeModel as EnumType with modelAsString: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.modeler",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "The modeler extension for classic generators in AutoRest.",
   "scripts": {
     "start": "dotnet src/bin/netcoreapp2.0/autorest.modeler.dll --server",

--- a/src/ObjectBuilder.cs
+++ b/src/ObjectBuilder.cs
@@ -124,7 +124,18 @@ namespace AutoRest.Modeler
                 else
                 {
                     enumType.ModelAsString = true;
-                    enumType.SetName( string.Empty);
+                    if (SwaggerObject is SwaggerParameter)
+                    {
+                        enumType.SetName((SwaggerObject as SwaggerParameter).Name.ToPascalCase());
+                    }
+                    else
+                    {
+                        // For a model property serviceTypeName is ModelName_PropertyName.
+                        // Hence we set the value after underscore as the name of the enum. 
+                        enumType.SetName(serviceTypeName.Substring(serviceTypeName.IndexOf("_") + 1).ToPascalCase());
+                    }
+                    
+                    Modeler.CodeModel.Add(enumType);
                 }
                 enumType.XmlProperties = (SwaggerObject as Schema)?.Xml;
                 return enumType;

--- a/test/SwaggerModelerTests.cs
+++ b/test/SwaggerModelerTests.cs
@@ -341,7 +341,7 @@ namespace AutoRest.Modeler.Tests
             Assert.Equal("Double double", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[5]));
             Assert.Equal("Decimal decimal", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[6]));
             Assert.Equal("String string", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[7]));
-            Assert.Equal("enum color", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[8]));
+            Assert.Equal("Color color", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[8]));
             Assert.Equal("ByteArray byte", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[9]));
             Assert.Equal("Boolean boolean", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[10]));
             Assert.Equal("Date date", CreateCSharpDeclarationString(codeModel.Methods[0].Parameters[11]));
@@ -358,7 +358,7 @@ namespace AutoRest.Modeler.Tests
                 new[] { new EnumValue { Name = "red" }, new EnumValue { Name = "blue" }, new EnumValue { Name = "green" } }
                     .ToList());
             Assert.True(variableEnumInPath.ModelAsString);
-            Assert.Empty(variableEnumInPath.Name.RawValue);
+            Assert.Equal("Color", variableEnumInPath.Name.RawValue);
 
             var variableEnumInQuery =
                 codeModel.Methods.First(m => m.Name == "List" && m.Group.IsNullOrEmpty())
@@ -372,7 +372,7 @@ namespace AutoRest.Modeler.Tests
                         new EnumValue {Name = "purple"}
                 }.ToList());
             Assert.True(variableEnumInQuery.ModelAsString);
-            Assert.Empty(variableEnumInQuery.Name.RawValue);
+            Assert.Equal("Color1", variableEnumInQuery.Name.RawValue);
 
             var differentEnum =
                 codeModel.Methods.First(m => m.Name == "List" && m.Group == "DiffEnums")
@@ -382,7 +382,7 @@ namespace AutoRest.Modeler.Tests
             Assert.Equal(differentEnum.Values,
                 new[] { new EnumValue { Name = "cyan" }, new EnumValue { Name = "yellow" } }.ToList());
             Assert.True(differentEnum.ModelAsString);
-            Assert.Empty(differentEnum.Name.RawValue);
+            Assert.Equal("Color3", differentEnum.Name.RawValue);
 
             var sameEnum =
                 codeModel.Methods.First(m => m.Name == "Get" && m.Group == "SameEnums")
@@ -393,7 +393,7 @@ namespace AutoRest.Modeler.Tests
                 new[] { new EnumValue { Name = "blue" }, new EnumValue { Name = "green" }, new EnumValue { Name = "red" } }
                     .ToList());
             Assert.True(sameEnum.ModelAsString);
-            Assert.Empty(sameEnum.Name.RawValue);
+            Assert.Equal("Color21", sameEnum.Name.RawValue);
 
             var modelEnum =
                 codeModel.ModelTypes.First(m => m.Name == "Product")
@@ -404,7 +404,7 @@ namespace AutoRest.Modeler.Tests
                 new[] { new EnumValue { Name = "red" }, new EnumValue { Name = "blue" }, new EnumValue { Name = "green" } }
                     .ToList());
             Assert.True(modelEnum.ModelAsString);
-            Assert.Empty(modelEnum.Name.RawValue);
+            Assert.Equal("Color2", modelEnum.Name.RawValue);
 
             var fixedEnum =
                 codeModel.ModelTypes.First(m => m.Name == "Product")
@@ -435,7 +435,7 @@ namespace AutoRest.Modeler.Tests
             Assert.Equal("RefColors", refEnum.Name);
 
 
-            Assert.Equal(2, codeModel.EnumTypes.Count);
+            Assert.Equal(7, codeModel.EnumTypes.Count);
             Assert.Equal("Colors", codeModel.EnumTypes.First().Name);
         }
 
@@ -540,7 +540,7 @@ namespace AutoRest.Modeler.Tests
             Assert.Equal("0", codeModel.ModelTypes.First(m => m.Name == "Product").Properties[8].DefaultValue);
 
             Assert.Equal("RefStrEnum", codeModel.ModelTypes.First(m => m.Name == "Product").Properties[9].Name);
-            Assert.Equal("enum", codeModel.ModelTypes.First(m => m.Name == "Product").Properties[9].ModelType.Name);
+            Assert.Equal("RefStrEnum", codeModel.ModelTypes.First(m => m.Name == "Product").Properties[9].ModelType.Name);
             Assert.Equal(false, codeModel.ModelTypes.First(m => m.Name == "Product").Properties[9].IsConstant);
             Assert.True(codeModel.ModelTypes.First(m => m.Name == "Product").Properties[9].DefaultValue.IsNullOrEmpty());
 


### PR DESCRIPTION
- We were previously treating such model properties and parameters as enums with ModelAsString true anyway. This PR adds them to the codeModel thus making the circle complete. 
- Once the PR is merged, codegenerators taking a dependency on the modeler with this this change will see an extra model in their library (For example: A static class with constant properties in case of C#)
- There should be no breaking changes to the generated client.