### PR TITLE
update autorest.testserver to remove constantinople vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.modeler/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "2.5.6",
+    "@microsoft.azure/autorest.testserver": "2.5.16",
     "autorest": "^2.0.4225",
     "coffee-script": "^1.11.1",
     "dotnet-sdk-2.0.0": "^1.4.4",


### PR DESCRIPTION
Update package to 2.5.16.
See https://github.com/Azure/autorest/issues/2942.